### PR TITLE
Add onUpdate to verifyDomain, initDkim resources

### DIFF
--- a/src/verify-ses-domain.ts
+++ b/src/verify-ses-domain.ts
@@ -87,6 +87,14 @@ export class VerifySesDomain extends Construct {
         },
         physicalResourceId: PhysicalResourceId.fromResponse('VerificationToken'),
       },
+      onUpdate: {
+        service: 'SES',
+        action: 'verifyDomainIdentity',
+        parameters: {
+          Domain: domainName,
+        },
+        physicalResourceId: PhysicalResourceId.fromResponse('VerificationToken'),
+      },
       onDelete: {
         service: 'SES',
         action: 'deleteIdentity',
@@ -128,6 +136,14 @@ export class VerifySesDomain extends Construct {
   private initDkimVerification(domainName: string) {
     return new AwsCustomResource(this, 'VerifyDomainDkim', {
       onCreate: {
+        service: 'SES',
+        action: 'verifyDomainDkim',
+        parameters: {
+          Domain: domainName,
+        },
+        physicalResourceId: PhysicalResourceId.of(domainName + '-verify-domain-dkim'),
+      },
+      onUpdate: {
         service: 'SES',
         action: 'verifyDomainDkim',
         parameters: {


### PR DESCRIPTION
Fixes error when deploying an update to the stack after upgrading CDK to 1.92.0 or later.

Error messages:

```
UPDATE_FAILED        | AWS::Route53::RecordSet

Vendor response doesn't contain VerificationToken
Vendor response doesn't contain DkimTokens.0
```