### PR TITLE
Update verify-ses-domain.ts

### DIFF
--- a/src/verify-ses-domain.ts
+++ b/src/verify-ses-domain.ts
@@ -115,6 +115,7 @@ export class VerifySesDomain extends Construct {
   getHostedZone(domainName: string): IHostedZone {
     return HostedZone.fromLookup(this, 'Zone', {
       domainName: domainName,
+      privateZone: false,
     });
   }
 


### PR DESCRIPTION
Fixes:

If you have a competing private zone named the same this change will put the records in the correct zone.

 