### PR TITLE
feat: add include email headers property

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,6 +43,7 @@ new VerifySesDomain(parent: Construct, name: string, props: IVerifySesDomainProp
   * **addMxRecord** (<code>boolean</code>)  Whether to automatically add a MX record to the hosted zone of your domain. __*Default*__: true
   * **addTxtRecord** (<code>boolean</code>)  Whether to automatically add a TXT record to the hosed zone of your domain. __*Default*__: true
   * **hostedZoneName** (<code>string</code>)  A hostedZone name to be matched with Route 53 record. __*Default*__: same as domainName
+  * **includeOriginalHeaders** (<code>boolean</code>)  Whether to include the original email headers in the notifications. __*Default*__: false
   * **notificationTopic** (<code>[aws_sns.Topic](#aws-cdk-lib-aws-sns-topic)</code>)  An SNS topic where bounces, complaints or delivery notifications can be sent to. __*Default*__: new topic will be created
   * **notificationTypes** (<code>Array<string></code>)  Select for which notification types you want to configure a topic. __*Default*__: [Bounce, Complaint]
 
@@ -106,6 +107,7 @@ Name | Type | Description
 **addMxRecord**? | <code>boolean</code> | Whether to automatically add a MX record to the hosted zone of your domain.<br/>__*Default*__: true
 **addTxtRecord**? | <code>boolean</code> | Whether to automatically add a TXT record to the hosed zone of your domain.<br/>__*Default*__: true
 **hostedZoneName**? | <code>string</code> | A hostedZone name to be matched with Route 53 record.<br/>__*Default*__: same as domainName
+**includeOriginalHeaders**? | <code>boolean</code> | Whether to include the original email headers in the notifications.<br/>__*Default*__: false
 **notificationTopic**? | <code>[aws_sns.Topic](#aws-cdk-lib-aws-sns-topic)</code> | An SNS topic where bounces, complaints or delivery notifications can be sent to.<br/>__*Default*__: new topic will be created
 **notificationTypes**? | <code>Array<string></code> | Select for which notification types you want to configure a topic.<br/>__*Default*__: [Bounce, Complaint]
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ new VerifySesDomain(this, 'SesDomainVerification', {
  * `addDkimRecord` Whether to automatically add DKIM records to the hosted zone of your domain. This only works if your domain is managed by Route53. Otherwise disable it. Default: `true`.
  * `notificationTopic` An SNS topic where bounces, complaints or delivery notifications can be sent to. If none is provided, a new topic will be created and used for all different notification types.
  * `notificationTypes` Select for which notification types you want to configure a topic. Default: `[Bounce, Complaint]`.
+ * `includeOriginalHeaders` Whether to include the original email headers in the notifications. Default: `false`.
 
 ### Verify an Email Address
 

--- a/test/__snapshots__/verify-ses-domain.test.ts.snap
+++ b/test/__snapshots__/verify-ses-domain.test.ts.snap
@@ -72,6 +72,51 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "VerifyExampleDomainAddBounceTopicHeaderssubdomainexampleorg863B3F6D": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "VerifyExampleDomainAddBounceTopicsubdomainexampleorgCustomResourcePolicy11D5C18D",
+        "VerifyExampleDomainAddBounceTopicsubdomainexampleorgD92CBEF0",
+        "VerifyExampleDomainAddBounceTopicHeaderssubdomainexampleorgCustomResourcePolicyEFD7055E",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"SES\\",\\"action\\":\\"setIdentityHeadersInNotificationsEnabled\\",\\"parameters\\":{\\"Enabled\\":true,\\"Identity\\":\\"sub-domain.example.org\\",\\"NotificationType\\":\\"Bounce\\"},\\"physicalResourceId\\":{\\"id\\":\\"sub-domain.example.org-set-Bounce-topic-headers\\"}}",
+        "InstallLatestAwsSdk": true,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::AWS",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "VerifyExampleDomainAddBounceTopicHeaderssubdomainexampleorgCustomResourcePolicyEFD7055E": Object {
+      "DependsOn": Array [
+        "VerifyExampleDomainAddBounceTopicsubdomainexampleorgCustomResourcePolicy11D5C18D",
+        "VerifyExampleDomainAddBounceTopicsubdomainexampleorgD92CBEF0",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ses:SetIdentityHeadersInNotificationsEnabled",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "VerifyExampleDomainAddBounceTopicHeaderssubdomainexampleorgCustomResourcePolicyEFD7055E",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "VerifyExampleDomainAddBounceTopicsubdomainexampleorgCustomResourcePolicy11D5C18D": Object {
       "DependsOn": Array [
         "VerifyExampleDomainSesNotificationTopicC05E5B2B",


### PR DESCRIPTION
Fixes:

If you want to to include the original email headers in the notifications you can do this by setting includeOriginalHeaders to true.